### PR TITLE
Registry aliases and minor fixes

### DIFF
--- a/common/src/main/java/com/ordana/dimensional_tears/DimensionalTearsPlatform.java
+++ b/common/src/main/java/com/ordana/dimensional_tears/DimensionalTearsPlatform.java
@@ -1,7 +1,9 @@
 package com.ordana.dimensional_tears;
 
 import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.biome.Biome;
@@ -40,4 +42,16 @@ public class DimensionalTearsPlatform {
         throw new AssertionError();
     }
 
+    public static void addAlias(Registry<?> registry, String path) {
+        addAlias(registry, ResourceLocation.fromNamespaceAndPath("portal_fluid", path.replace("dimensional_tears", "portal_fluid")), ResourceLocation.fromNamespaceAndPath("dimensional_tears", path));
+    }
+
+	public static void addAlias(Registry<?> registry, String oldPath, String newPath) {
+        addAlias(registry, ResourceLocation.fromNamespaceAndPath("portal_fluid", oldPath), ResourceLocation.fromNamespaceAndPath("dimensional_tears", newPath));
+	}
+
+    @ExpectPlatform
+    public static void addAlias(Registry<?> registry, ResourceLocation oldPath, ResourceLocation newPath) {
+        throw new AssertionError();
+    }
 }

--- a/common/src/main/java/com/ordana/dimensional_tears/blocks/DimensionalTearsCauldronBlock.java
+++ b/common/src/main/java/com/ordana/dimensional_tears/blocks/DimensionalTearsCauldronBlock.java
@@ -20,7 +20,9 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemUtils;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -139,4 +141,8 @@ public class DimensionalTearsCauldronBlock extends AbstractCauldronBlock {
         return InteractionResult.sidedSuccess(level.isClientSide());
     }
 
+    @Override
+    public ItemStack getCloneItemStack(LevelReader levelReader, BlockPos blockPos, BlockState blockState) {
+        return Items.CAULDRON.getDefaultInstance();
+    }
 }

--- a/common/src/main/java/com/ordana/dimensional_tears/mixins/dimensional_tears/LakeFeatureMixin.java
+++ b/common/src/main/java/com/ordana/dimensional_tears/mixins/dimensional_tears/LakeFeatureMixin.java
@@ -7,20 +7,23 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.LakeFeature;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 /**
- * <a href="https://github.com/cassiancc/ProjectInfinity/blob/master/src/main/java/net/lerariemann/infinity/mixin/fixes/LakeFeatureMixin.java">Originally authored by LeraRiemann</a> (modified from)
+ * <a href="https://tangled.org/lerariemann.nekoweb.org/ProjectInfinity/blob/master/src/main/java/net/lerariemann/infinity/mixin/fixes/LakeFeatureMixin.java">Originally authored by LeraRiemann</a> (modified from)
  */
 @SuppressWarnings("deprecation")
 @Mixin(LakeFeature.class)
 public class LakeFeatureMixin {
 
-    @WrapOperation(method="place(Lnet/minecraft/world/level/levelgen/feature/FeaturePlaceContext;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/WorldGenLevel;getBiome(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Holder;"))
-    private Holder<Biome> fixVanillaLakeCrash(WorldGenLevel instance, BlockPos blockPos, Operation<Holder<Biome>> original, @Local(name = "blockPos") BlockPos origin) {
-        return instance.getBiome(origin);
+    @WrapOperation(method="place(Lnet/minecraft/world/level/levelgen/feature/FeaturePlaceContext;)Z", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/world/level/WorldGenLevel;getBiome(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/Holder;"))
+    Holder<Biome> fixVanillaLakeCrash(WorldGenLevel instance, BlockPos blockPos, Operation<Holder<Biome>> original,
+                                      @Local(argsOnly = true) FeaturePlaceContext<LakeFeature.Configuration> context) {
+        return context.level().getBiome(context.origin());
     }
 
 }

--- a/common/src/main/java/com/ordana/dimensional_tears/reg/ModBlocks.java
+++ b/common/src/main/java/com/ordana/dimensional_tears/reg/ModBlocks.java
@@ -5,6 +5,7 @@ import com.ordana.dimensional_tears.DimensionalTearsRoot;
 import com.ordana.dimensional_tears.blocks.DimensionalTearsCauldronBlock;
 import net.mehvahdjukaar.moonlight.api.platform.RegHelper;
 import net.minecraft.core.cauldron.CauldronInteraction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
@@ -38,6 +39,9 @@ public interface ModBlocks {
         return RegHelper.registerBlock(DimensionalTearsRoot.res(path), blockSupplier);
     }
 
-    static void init() {}
+    static void init() {
+        DimensionalTearsPlatform.addAlias(BuiltInRegistries.BLOCK, "portal_fluid", "dimensional_tears");
+        DimensionalTearsPlatform.addAlias(BuiltInRegistries.BLOCK, "portal_cauldron", "dimensional_tears_cauldron");
+    }
 
 }

--- a/common/src/main/java/com/ordana/dimensional_tears/reg/ModFluids.java
+++ b/common/src/main/java/com/ordana/dimensional_tears/reg/ModFluids.java
@@ -1,8 +1,11 @@
 package com.ordana.dimensional_tears.reg;
 
+import com.ordana.dimensional_tears.DimensionalTearsPlatform;
 import com.ordana.dimensional_tears.DimensionalTearsRoot;
 import com.ordana.dimensional_tears.fluids.DimensionalTearsFluid;
 import net.mehvahdjukaar.moonlight.api.platform.RegHelper;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 
@@ -14,6 +17,7 @@ public interface ModFluids {
     Supplier<FlowingFluid> DIMENSIONAL_TEARS = registerFluid("dimensional_tears", DimensionalTearsFluid.Source::new);
 
     private static <T extends Fluid> Supplier<T> registerFluid(String path, Supplier<T> fluidSupplier) {
+        DimensionalTearsPlatform.addAlias(BuiltInRegistries.FLUID, path);
         return RegHelper.registerFluid(DimensionalTearsRoot.res(path), fluidSupplier);
     }
 

--- a/common/src/main/java/com/ordana/dimensional_tears/reg/ModItems.java
+++ b/common/src/main/java/com/ordana/dimensional_tears/reg/ModItems.java
@@ -1,10 +1,12 @@
 package com.ordana.dimensional_tears.reg;
 
+import com.ordana.dimensional_tears.DimensionalTearsPlatform;
 import com.ordana.dimensional_tears.DimensionalTearsRoot;
 import com.ordana.dimensional_tears.items.DimensionalTearsBottleItem;
 import com.ordana.dimensional_tears.items.DimensionalTearsBucketItem;
 import net.mehvahdjukaar.moonlight.api.misc.RegSupplier;
 import net.mehvahdjukaar.moonlight.api.platform.RegHelper;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.Rarity;
@@ -35,6 +37,7 @@ public interface ModItems {
     );
 
     static <T extends Item> RegSupplier<T> regItem(String path, Supplier<T> itemSupplier) {
+        DimensionalTearsPlatform.addAlias(BuiltInRegistries.ITEM, path);
         return RegHelper.registerItem(DimensionalTearsRoot.res(path), itemSupplier);
     }
 

--- a/fabric/src/main/java/com/ordana/dimensional_tears/fabric/DimensionalTearsPlatformImpl.java
+++ b/fabric/src/main/java/com/ordana/dimensional_tears/fabric/DimensionalTearsPlatformImpl.java
@@ -5,7 +5,9 @@ import com.ordana.dimensional_tears.fluids.DimensionalTearsFluid;
 import com.ordana.dimensional_tears.reg.ModTags;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.biome.Biome;
@@ -35,6 +37,10 @@ public class DimensionalTearsPlatformImpl {
 
     public static boolean isEyeInDimTears(Entity entity) {
         return entity.isEyeInFluid(ModTags.DIMENSIONAL_TEARS);
+    }
+
+    public static void addAlias(Registry<?> registry, ResourceLocation oldPath, ResourceLocation newPath) {
+        registry.addAlias(oldPath, newPath);
     }
 
 }

--- a/fabric/src/main/java/com/ordana/dimensional_tears/fabric/DimensionalTearsRootFabric.java
+++ b/fabric/src/main/java/com/ordana/dimensional_tears/fabric/DimensionalTearsRootFabric.java
@@ -43,7 +43,7 @@ public class DimensionalTearsRootFabric implements ModInitializer {
         UseBlockCallback.EVENT.register(DimensionalTearsRootFabric::onRightClickBlock);
         ServerLifecycleEvents.SERVER_STARTING.register(server -> {
             // delayed to prevent a crash from accessing it before registration
-            CauldronFluidContent.registerCauldron(ModBlocks.DIMENSIONAL_TEARS.get(), ModFluids.DIMENSIONAL_TEARS.get(), FluidConstants.BOTTLE, DimensionalTearsCauldronBlock.LEVEL);
+            CauldronFluidContent.registerCauldron(ModBlocks.DIMENSIONAL_TEARS_CAULDRON.get(), ModFluids.DIMENSIONAL_TEARS.get(), FluidConstants.BOTTLE, DimensionalTearsCauldronBlock.LEVEL);
         });
     }
 

--- a/neoforge/src/main/java/com/ordana/dimensional_tears/neoforge/DimensionalTearsPlatformImpl.java
+++ b/neoforge/src/main/java/com/ordana/dimensional_tears/neoforge/DimensionalTearsPlatformImpl.java
@@ -3,7 +3,9 @@ package com.ordana.dimensional_tears.neoforge;
 import com.ordana.dimensional_tears.DimensionalTearsRoot;
 import com.ordana.dimensional_tears.blocks.DimensionalTearsBlock;
 import com.ordana.dimensional_tears.neoforge.reg.ModFluidTypes;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.biome.Biome;
@@ -31,6 +33,10 @@ public class DimensionalTearsPlatformImpl {
 
     public static boolean isEyeInDimTears(Entity entity) {
         return DimensionalTearsRoot.isInitiated() && entity.isEyeInFluidType(ModFluidTypes.DIMENSIONAL_TEARS_TYPE.get());
+    }
+
+    public static void addAlias(Registry<?> registry, ResourceLocation oldPath, ResourceLocation newPath) {
+        registry.addAlias(oldPath, newPath);
     }
 
 }

--- a/neoforge/src/main/java/com/ordana/dimensional_tears/neoforge/NeoForgeEvents.java
+++ b/neoforge/src/main/java/com/ordana/dimensional_tears/neoforge/NeoForgeEvents.java
@@ -31,7 +31,7 @@ public class NeoForgeEvents {
 
     @SubscribeEvent(priority = EventPriority.LOW)
     public static void registerCauldron(RegisterCauldronFluidContentEvent event) {
-        event.register(ModBlocks.DIMENSIONAL_TEARS.get(), ModFluids.DIMENSIONAL_TEARS.get(), FluidType.BUCKET_VOLUME, DimensionalTearsCauldronBlock.LEVEL);
+        event.register(ModBlocks.DIMENSIONAL_TEARS_CAULDRON.get(), ModFluids.DIMENSIONAL_TEARS.get(), FluidType.BUCKET_VOLUME, DimensionalTearsCauldronBlock.LEVEL);
     }
 
     @SubscribeEvent(priority = EventPriority.LOW)


### PR DESCRIPTION
- Fixed pick block on Cauldrons not returning a cauldron
- Added registry aliases for old IDs
- Fixed cauldron fluid content registration typo
- Reverted changes to lake mixin that crashed in production, fixed credit